### PR TITLE
fix handshake when Browser sends NTML Type1 token immediately

### DIFF
--- a/lib/Mojolicious/Plugin/SPNEGO.pm
+++ b/lib/Mojolicious/Plugin/SPNEGO.pm
@@ -14,15 +14,22 @@ sub register {
     $app->helper(
         ntlm_auth => sub {
             my $c = shift;
-            my $helper_cfg = ref ${_}[0] ? %{${_}[0]} : { @_ };
+            my $helper_cfg = ref ${_}[0] ? ${_}[0] : { @_ };
             my $cfg = { %$plugin_cfg, %$helper_cfg };
             my $cId = $c->tx->connection;
-            my $cCache = $cCache{$cId} //= { status => 'init' };
-            return if $cCache->{status} eq 'authenticated';
 
             my $authorization = $c->req->headers->header('Authorization') // '';
             my ($AuthBase64) = ($authorization =~ /^NTLM\s(.+)$/);
+            $c->app->log->debug("AuthBase64: $AuthBase64");
+
+            my $cCache = $cCache{$cId} //= {
+                status => $AuthBase64 ? 'expectType1' : 'init'
+            };
+            return if $cCache->{status} eq 'authenticated';
+
             my ($status) = ($cCache->{status} =~ /^expect(Type[13])/);
+            $c->app->log->debug("status: $status");
+
             if ($AuthBase64 and $status){
                 for ($status){
                     my $ldap = $cCache->{ldapObj} //= Net::LDAP::SPNEGO->new(


### PR DESCRIPTION
The fix is trival. I just check for the NTLM token first and set status to 'expectType1' if its already there.
I left 2 IMHO helpful debug messages in. Feel free to delete them. 
